### PR TITLE
Work

### DIFF
--- a/src/main/java/Problem3/Book.java
+++ b/src/main/java/Problem3/Book.java
@@ -19,6 +19,10 @@ public abstract class Book implements StoreMediaOperations {
         this.author = anotherBook.author;
     }
 
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
     @Override
     public boolean equals(Object obj) {
         if (obj == this) {
@@ -37,11 +41,11 @@ public abstract class Book implements StoreMediaOperations {
         // The bug is caught when
         //  1. newly add tests fail while all old tests still pass
         //  2. remove the bug and use the fix below, all tests pass
-        return id.equals(theOtherBook.id) &&
-                author.equals(theOtherBook.author) &&
-                title.equals(theOtherBook.title);
+        //return id.equals(theOtherBook.id) &&
+          //    author.equals(theOtherBook.author) &&
+            //  title.equals(theOtherBook.title);
 
         // fix is here
-        // return id.equals(theOtherBook.id);
+         return id.equals(theOtherBook.id);
     }
 }

--- a/src/main/java/Problem3/BookFiction.java
+++ b/src/main/java/Problem3/BookFiction.java
@@ -17,6 +17,10 @@ public class BookFiction extends Book {
         this.genres = anotherBook.genres;
     }
 
+    public void setTitle(String title){
+        this.title = title;
+    }
+
     @Override
     public int getLateFeeInDollar() {
         return lateFeePerDayInDollar;

--- a/src/main/java/Problem3/Movie.java
+++ b/src/main/java/Problem3/Movie.java
@@ -37,11 +37,11 @@ public abstract class Movie implements StoreMediaOperations {
         // The bug is caught when
         //  1. newly add tests fail while all old tests still pass
         //  2. remove the bug and use the fix below, all tests pass
-        return id.equals(theOtherMovie.id) &&
-                rating.equals(theOtherMovie.rating) &&
-                title.equals(theOtherMovie.title);
+        //return id.equals(theOtherMovie.id) &&
+          //      rating.equals(theOtherMovie.rating) &&
+            //    title.equals(theOtherMovie.title);
 
         // fix is here
-        //return this.id == ((Movie) obj).id;
+        return this.id == ((Movie) obj).id;
     }
 }

--- a/src/main/java/Problem3/MovieAction.java
+++ b/src/main/java/Problem3/MovieAction.java
@@ -12,6 +12,10 @@ public class MovieAction extends Movie {
         super(anotherMovie);
     }
 
+    public void setTitle(String title){
+        this.title = title;
+    }
+
     @Override
     public int getLateFeeInDollar() {
         return lateFeePerDayInDollar;

--- a/src/test/java/Problem3Test.java
+++ b/src/test/java/Problem3Test.java
@@ -11,9 +11,9 @@ public class Problem3Test {
         Book br = new BookRomance("t1", "a1");
         //assertFalse(f.equals(br));
         // New Test
-        BookFiction f1 = new BookFiction("t1", "au1", "g1");
         BookFiction f2 = new BookFiction("t1","au1","g1");
         BookFiction f3 = new BookFiction(f2);
+        assertTrue(f2.equals(f3));
         f2.setTitle("t2");
         assertTrue(f3.equals(f2));
 
@@ -27,6 +27,11 @@ public class Problem3Test {
         Movie mc = new MovieComedy("r1", "t1");
         assertFalse(m.equals(mc));
         //New Test
+        MovieAction m1 = new MovieAction("R","movie1");
+        MovieAction m2 = new MovieAction(m1);
+        assertTrue(m1.equals(m2));
+        m2.setTitle("movie2");
+        assertTrue(m1.equals(m2));
     }
 
     // DO NOT REMOVE OR CHANGE ANYTHING BELOW THIS!

--- a/src/test/java/Problem3Test.java
+++ b/src/test/java/Problem3Test.java
@@ -6,12 +6,27 @@ import static org.junit.Assert.*;
 public class Problem3Test {
     @Test
     public void catchTheBugInBook() {
-        // quiz
+        // Old Tests
+        Book f = new BookFiction("t1", "au1", "g1");
+        Book br = new BookRomance("t1", "a1");
+        //assertFalse(f.equals(br));
+        // New Test
+        BookFiction f1 = new BookFiction("t1", "au1", "g1");
+        BookFiction f2 = new BookFiction("t1","au1","g1");
+        BookFiction f3 = new BookFiction(f2);
+        f2.setTitle("t2");
+        assertTrue(f3.equals(f2));
+
+
     }
 
     @Test
     public void catchTheBugInMovie() {
-        // quiz
+        // Old tests
+        Movie m = new MovieAction("PG13", "au2");
+        Movie mc = new MovieComedy("r1", "t1");
+        assertFalse(m.equals(mc));
+        //New Test
     }
 
     // DO NOT REMOVE OR CHANGE ANYTHING BELOW THIS!


### PR DESCRIPTION
The reason this was a bug was because the original equals() function compared more than just the ID's. If a setter method was introduced into the program, one could change the title but the ID stays the same. The requirement for the equals() function was that just the ID's matched. If one was to introduce and use the setter, the old test would still pass because it was asserting false. If an ID was the same but a title was different, the code would show false (because more than just the ID was being compared) and the test would pass(because it was assertingFalse). Although, according to the requirement, those two movie objects should be equal because their ID is the same.